### PR TITLE
feat: Improve navigation between all the pages

### DIFF
--- a/lib/end_game/view/end_game_page.dart
+++ b/lib/end_game/view/end_game_page.dart
@@ -1,10 +1,15 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:gamepads/gamepads.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:lightrunners/game/game.dart';
+import 'package:lightrunners/title/view/title_page.dart';
 import 'package:lightrunners/ui/ui.dart';
+import 'package:lightrunners/utils/gamepad_navigator.dart';
 import 'package:lightrunners/widgets/widgets.dart';
 
-class EndGamePage extends StatelessWidget {
+class EndGamePage extends StatefulWidget {
   const EndGamePage({
     required this.scores,
     super.key,
@@ -14,15 +19,40 @@ class EndGamePage extends StatelessWidget {
 
   static Route<void> route(Map<Color, int> scores) {
     return MaterialPageRoute<void>(
+      maintainState: false,
       builder: (_) => EndGamePage(scores: scores),
     );
+  }
+
+  @override
+  State<EndGamePage> createState() => _EndGamePageState();
+}
+
+class _EndGamePageState extends State<EndGamePage> {
+  late StreamSubscription<GamepadEvent> _gamepadSubscription;
+  late GamepadNavigator _gamepadNavigator;
+
+  @override
+  void initState() {
+    super.initState();
+    _gamepadNavigator = GamepadNavigator(
+      onAny: () => Navigator.of(context).pushReplacement(TitlePage.route()),
+    );
+    _gamepadSubscription = Gamepads.events.listen(_gamepadNavigator.handle);
+  }
+
+  @override
+  void dispose() {
+    _gamepadSubscription.cancel();
+
+    super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     final fontFamily = GoogleFonts.bungee().fontFamily;
 
-    final scores = this.scores.entries.toList()
+    final scores = widget.scores.entries.toList()
       ..sort((a, b) => b.value.compareTo(a.value));
 
     const baseSize = 64;
@@ -100,7 +130,8 @@ class EndGamePage extends StatelessWidget {
           ),
           OpacityBlinker(
             child: TextButton(
-              onPressed: () => Navigator.pop(context),
+              onPressed: () =>
+                  Navigator.of(context).pushReplacement(TitlePage.route()),
               child: Text(
                 'Press any button to continue',
                 style: TextStyle(

--- a/lib/game/view/game_page.dart
+++ b/lib/game/view/game_page.dart
@@ -10,6 +10,7 @@ class GamePage extends StatefulWidget {
 
   static Route<void> route({required List<String?> players}) {
     return MaterialPageRoute<void>(
+      maintainState: false,
       builder: (_) => GamePage(players: players),
     );
   }

--- a/lib/lobby/view/lobby_page.dart
+++ b/lib/lobby/view/lobby_page.dart
@@ -5,7 +5,9 @@ import 'package:flutter/services.dart';
 import 'package:gamepads/gamepads.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:lightrunners/game/view/game_page.dart';
+import 'package:lightrunners/title/view/title_page.dart';
 import 'package:lightrunners/ui/palette.dart';
+import 'package:lightrunners/utils/gamepad_map.dart';
 import 'package:lightrunners/widgets/screen_scaffold.dart';
 
 class LobbyPage extends StatefulWidget {
@@ -13,6 +15,7 @@ class LobbyPage extends StatefulWidget {
 
   static Route<void> route() {
     return MaterialPageRoute<void>(
+      maintainState: false,
       builder: (_) => const LobbyPage(),
     );
   }
@@ -34,10 +37,11 @@ class _LobbyPageState extends State<LobbyPage> {
 
     _gamepadSubscription = Gamepads.events.listen((GamepadEvent event) {
       setState(() {
-        if ((event.key == '7' || event.key == 'line.horizontal.3.circle') &&
-            event.value == 1.0) {
-          // The start key was pressed
-          Navigator.of(context).push(GamePage.route(players: _players));
+        if (startButton.matches(event)) {
+          Navigator.of(context)
+              .pushReplacement(GamePage.route(players: _players));
+        } else if (selectButton.matches(event)) {
+          Navigator.of(context).pushReplacement(TitlePage.route());
         } else if (!_players.contains(event.gamepadId) && event.key == '0') {
           _players.add(event.gamepadId);
         }
@@ -70,7 +74,8 @@ class _LobbyPageState extends State<LobbyPage> {
           });
         } else if (event.isKeyPressed(LogicalKeyboardKey.enter)) {
           // The start key was pressed
-          Navigator.of(context).push(GamePage.route(players: _players));
+          Navigator.of(context)
+              .pushReplacement(GamePage.route(players: _players));
         }
       },
       child: ScreenScaffold(

--- a/lib/title/view/title_page.dart
+++ b/lib/title/view/title_page.dart
@@ -7,6 +7,13 @@ import 'package:lightrunners/widgets/controller_menu.dart';
 import 'package:lightrunners/widgets/screen_scaffold.dart';
 
 class TitlePage extends StatelessWidget {
+  static Route<void> route() {
+    return MaterialPageRoute<void>(
+      maintainState: false,
+      builder: (_) => const TitlePage(),
+    );
+  }
+
   const TitlePage({super.key});
 
   @override
@@ -26,13 +33,13 @@ class TitlePage extends StatelessWidget {
                   (
                     name: 'Start',
                     onPressed: () {
-                      Navigator.of(context).push(LobbyPage.route());
+                      Navigator.of(context).pushReplacement(LobbyPage.route());
                     },
                   ),
                   (
                     name: 'LeaderBoard',
                     onPressed: () {
-                      Navigator.of(context).push(
+                      Navigator.of(context).pushReplacement(
                         EndGamePage.route(
                           {
                             GamePalette.blue: 100,

--- a/lib/utils/gamepad_map.dart
+++ b/lib/utils/gamepad_map.dart
@@ -39,15 +39,18 @@ class GamepadAnalogAxis implements GamepadKey {
 }
 
 class GamepadButtonKey extends GamepadKey {
-  final String key;
+  final String linuxKeyName;
+  final String macosKeyName;
 
-  const GamepadButtonKey({required this.key});
+  const GamepadButtonKey({
+    required this.linuxKeyName,
+    required this.macosKeyName,
+  });
 
   @override
   bool matches(GamepadEvent event) {
-    return event.key == key &&
-        event.value == 1.0 &&
-        event.type == KeyType.button;
+    final isKey = event.key == linuxKeyName || event.key == macosKeyName;
+    return isKey && event.value == 1.0 && event.type == KeyType.button;
   }
 }
 
@@ -81,5 +84,17 @@ const rightYAxis = GamepadAnalogAxis(
   macosKeyName: 'r.joystick - yAxis',
 );
 
-const GamepadKey aButton = GamepadButtonKey(key: '0');
+const GamepadKey aButton = GamepadButtonKey(
+  linuxKeyName: '0',
+  macosKeyName: '???',
+);
+const GamepadKey startButton = GamepadButtonKey(
+  linuxKeyName: '7',
+  macosKeyName: 'line.horizontal.3.circle',
+);
+const GamepadKey selectButton = GamepadButtonKey(
+  linuxKeyName: '6',
+  macosKeyName: '???',
+);
+
 const GamepadKey r1Bumper = GamepadBumperKey(key: '5');

--- a/lib/utils/gamepad_navigator.dart
+++ b/lib/utils/gamepad_navigator.dart
@@ -5,11 +5,13 @@ class GamepadNavigator {
   final Function(int)? xAxisHandler;
   final Function(int)? yAxisHandler;
   final Function()? onAction;
+  final Function()? onAny;
 
   GamepadNavigator({
     this.xAxisHandler,
     this.yAxisHandler,
     this.onAction,
+    this.onAny,
   });
 
   int _getValue(GamepadEvent event) {
@@ -17,6 +19,10 @@ class GamepadNavigator {
   }
 
   void handle(GamepadEvent event) {
+    if (event.value == 1.0) {
+      onAny?.call();
+    }
+
     if (leftXAxis.matches(event)) {
       final value = _getValue(event);
       if (value != 0) {


### PR DESCRIPTION
Fixes https://github.com/flame-engine/lightrunners/issues/53

Note: we cannot use push/pop because the per-page gamepad listeners do not work.
For now I am replacing everything with pushReplcement, since it works better.
We dont have mobile support for now anyway.
In the future we would need to have a single gamepad listener in the root and do the drill down to the current page ourselves as flutter doesn't support that.